### PR TITLE
add indent support for protobuf extenstion

### DIFF
--- a/indent/proto.vim
+++ b/indent/proto.vim
@@ -27,11 +27,11 @@ function! PbIndent(lnum)
 
   let l:ind = l:previ
 
-  if l:prevl =~ '[({]\s*$'
+  if l:prevl =~ '[\[({]\s*$'
     let l:ind += shiftwidth()
   endif
 
-  if l:thisl =~ '^\s*[)}]'
+  if l:thisl =~ '^\s*[)}\]]'
     let l:ind -= shiftwidth()
   endif
 


### PR DESCRIPTION
add indent support for protobuf extenstion annotations
```
// Request message for LibraryService.GetBook.
message GetBookRequest {
  // The name of the book to retrieve.
  string name = 1 [ 
    (google.api.field_behavior) = REQUIRED,
    (google.api.resource_reference).type = "Book"
  ];  
}
```